### PR TITLE
bug/26- Fixed thread issue in `ngrok.py` module

### DIFF
--- a/chatgpt_slack_lib/ngrok_wrapper/ngrok.py
+++ b/chatgpt_slack_lib/ngrok_wrapper/ngrok.py
@@ -33,9 +33,14 @@ class TunnelNg:
         self.callback_on_tunnel_change(self.default_tunnel)
 
     def stop_tunnel(self):
-        self.tunnel_runner.stop_it()
-        self.tunnel_process_runner.stop_it()
+        if self.tunnel_runner:
+            self.tunnel_runner.stop_it()
+        if self.tunnel_process_runner:
+            self.tunnel_process_runner.stop_it()
         ngrok.kill()
+
+        self.tunnel_runner = None
+        self.tunnel_process_runner = None
 
 
     def ngrok_process(self):


### PR DESCRIPTION
## Fixed: 

1. After stoping thread, assigned it to `None` so that we can create new thread -- Before using `stop_it` method on thread, checked it's existence

### Ref:

- #26 